### PR TITLE
Workaround for USB/sleep issues

### DIFF
--- a/config.h
+++ b/config.h
@@ -22,9 +22,9 @@
 // #define KEYBOARD_HOST // Force host mode
 // #define KEYBOARD_REMOTE // Force remote mode
 
-// Workaround for freezing after MacOS sleep
-// Only enable if you have issues
-// #define USB_SUSPEND_WAKEUP_DELAY 500
+// Workarounds for boot/sleep issues
+#define USB_SUSPEND_WAKEUP_DELAY 250
+#define NO_SUSPEND_POWER_DOWN
 
 /* USB Device descriptor parameter */
 #define VENDOR_ID       0x6E61
@@ -43,7 +43,7 @@
 #define TAPPING_FORCE_HOLD
 
 /* split config */
-// #define SPLIT_USB_DETECT // Enable if you have issues with USB 
+// #define SPLIT_USB_DETECT // Enable if you have issues with USB
 #define SOFT_SERIAL_PIN E6
 #define SPLIT_HAND_PIN B6
 #define DISABLE_SYNC_TIMER

--- a/snap.c
+++ b/snap.c
@@ -147,3 +147,28 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
 
     return true;
 }
+
+// Workaround for sleep issues
+void suspend_power_down_kb(void) {
+    suspend_power_down_user();
+
+    // Turn off underglow
+#    if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
+    rgblight_suspend();
+#    endif
+    // Turn off OLED
+#    ifdef OLED_ENABLE
+    oled_off();
+#    endif
+    // Hack: force one last sync
+    matrix_post_scan();
+}
+
+void suspend_wakeup_init_kb(void) {
+    suspend_wakeup_init_user();
+
+    // Wake up underglow
+#if defined(RGBLIGHT_SLEEP) && defined(RGBLIGHT_ENABLE)
+    rgblight_wakeup();
+#endif
+}


### PR DESCRIPTION
There is something funky going on with the low power mode entry in TMK core. I never saw issues with the nibble because sleep mode was never enabled. 

This works around it by disabling the entry into LPM and simulating the same steps -- namely turning off the OLED and RGB on sleep/power down, and turning them back on on wake, but NOT putting the 32U4 into LPM after doing so.